### PR TITLE
Re-expose math operators for PersistingObservableValue

### DIFF
--- a/src/sensesp/system/observablevalue.h
+++ b/src/sensesp/system/observablevalue.h
@@ -95,6 +95,12 @@ template <class T>
 class PersistingObservableValue : public ObservableValue<T>,
                                   public FileSystemSaveable {
  public:
+  using ObservableValue<T>::operator=;
+  using ObservableValue<T>::operator++;
+  using ObservableValue<T>::operator--;
+  using ObservableValue<T>::operator+=;
+  using ObservableValue<T>::operator-=;
+
   PersistingObservableValue(const T& value, String config_path = "")
       : ObservableValue<T>(value), FileSystemSaveable(config_path) {
     load();


### PR DESCRIPTION
C++ specs hide operator overrides in descendant classes unless explicitly exposed.