### PR TITLE
Add "supportsPut" to metadata

### DIFF
--- a/examples/smart_switch/smart_switch_example.cpp
+++ b/examples/smart_switch/smart_switch_example.cpp
@@ -109,8 +109,16 @@ void setup() {
   // to be reported to the server every 10 seconds, regardless of whether
   // or not it has changed.  That keeps the value on the server fresh and
   // lets the server know the switch is still alive.
+  // To inform other devices that this is a switch that supports "PUT" 
+  // requests, we define appropriate metadata for the sk path.
+  auto* skMetadata = new SKMetadata("bool", 
+                                "Engine Room Lights", 
+                                "Switches lights in the engine room", 
+                                "Engine Room", 
+                                -1.0f,
+                                true);
   load_switch->connect_to(new Repeat<bool, bool>(10000))
-      ->connect_to(new SKOutputBool(sk_path, config_path_sk_output));
+      ->connect_to(new SKOutputBool(sk_path, config_path_sk_output, skMetadata));
 }
 
 void loop() { event_loop()->tick(); }

--- a/src/sensesp/signalk/signalk_metadata.cpp
+++ b/src/sensesp/signalk/signalk_metadata.cpp
@@ -4,12 +4,13 @@ namespace sensesp {
 
 SKMetadata::SKMetadata(const String& units, const String& display_name,
                        const String& description, const String& short_name,
-                       float timeout)
+                       float timeout, bool supports_put)
     : display_name_{display_name},
       units_{units},
       description_{description},
       short_name_{short_name},
-      timeout_{timeout} {}
+      timeout_{timeout},
+      supports_put_{supports_put} {}
 
 void SKMetadata::add_entry(const String& sk_path, JsonArray& meta) {
   JsonObject json = meta.add<JsonObject>();
@@ -34,6 +35,10 @@ void SKMetadata::add_entry(const String& sk_path, JsonArray& meta) {
 
   if (this->timeout_ >= 0.0) {
     val["timeout"] = this->timeout_;
+  }
+
+  if (this->supports_put_) {
+    val["supportsPut"] = this->supports_put_;
   }
 }
 

--- a/src/sensesp/signalk/signalk_metadata.h
+++ b/src/sensesp/signalk/signalk_metadata.h
@@ -28,6 +28,7 @@ class SKMetadata {
   String description_;
   String short_name_;
   float timeout_;
+  bool supports_put_;
 
   /**
    * @param units The unit of measurement the value represents. See
@@ -43,13 +44,15 @@ class SKMetadata {
    * @param timeout Tells the consumer how long it should consider the value
    * valid. This value is specified in seconds. Specify -1.0 if you do not
    * want to specify a timeout.
+   * @param supports_put Indicates whether this path supports PUT requests.
+   * Defaults to false.
    */
   SKMetadata(const String& units, const String& display_name = "",
              const String& description = "", const String& short_name = "",
-             float timeout = -1.0);
+             float timeout = -1.0, bool supports_put = false);
 
   /// Default constructor creates a blank Metadata structure
-  SKMetadata() : timeout_{-1} {}
+  SKMetadata() : timeout_{-1}, supports_put_{false} {}
 
   /**
    * Adds an entry to the specified meta array that represents this metadata


### PR DESCRIPTION
The "supportsPut" property is needed by devices that use an SKPutRequestListener to allow other devices to know the path can be updated via a PUT request.