### PR TITLE
Do NOT specify any "unit" for "bool" types or KIP will break

### DIFF
--- a/examples/smart_switch/smart_switch_example.cpp
+++ b/examples/smart_switch/smart_switch_example.cpp
@@ -110,8 +110,9 @@ void setup() {
   // or not it has changed.  That keeps the value on the server fresh and
   // lets the server know the switch is still alive.
   // To inform other devices that this is a switch that supports "PUT" 
-  // requests, we define appropriate metadata for the sk path.
-  auto* skMetadata = new SKMetadata("bool", 
+  // requests, we define appropriate metadata for the sk path. Note that
+  // "bool" does not need to use the "units" property as it is implied.
+  auto* skMetadata = new SKMetadata("", 
                                 "Engine Room Lights", 
                                 "Switches lights in the engine room", 
                                 "Engine Room", 

--- a/src/sensesp/signalk/signalk_metadata.h
+++ b/src/sensesp/signalk/signalk_metadata.h
@@ -31,7 +31,8 @@ class SKMetadata {
   bool supports_put_;
 
   /**
-   * @param units The unit of measurement the value represents. See
+   * @param units The unit of measurement the value represents. This is primarily used
+   * for numeric values. If NO unit needs to be specified, pass an empty string. See
    * https://github.com/SignalK/specification/blob/master/schemas/definitions.json#L87
    * @param display_name This is used on or near any display or gauge which
    * shows the data.


### PR DESCRIPTION
After direct discussion with the KIP developer, it has been determined that the "units" property should NOT be specified AT ALL for boolean values